### PR TITLE
increase timeout from 300s to 900s

### DIFF
--- a/tools/trivy.sh
+++ b/tools/trivy.sh
@@ -10,8 +10,8 @@ fi
 echo " "
 echo "running Trivy scan for Kubernetes ..."
 
-#trivy k8s --report=all --slow --format=json --output=trivy.json cluster
-trivy k8s --report=all --slow --format=table --output=trivy.out cluster
+#trivy k8s --report=all --slow --format=json --output=trivy.json --timeout 900s cluster
+trivy k8s --report=all --slow --format=table --output=trivy.out --timeout 900s cluster
 
 echo " "
 echo "================================================================================================================="


### PR DESCRIPTION
By starting a trivy scan on my freshly newly deployed cluster I encountered two times a trivy timeout error: "context deadline exceeded"
I could solve this on the third scan by increasing the default timeout from 300s to 900s as recommended in the documentation: https://aquasecurity.github.io/trivy/v0.22.0/getting-started/troubleshooting/#timeout